### PR TITLE
Remove requirement for pre-existing directory for the output

### DIFF
--- a/Plot_Results_econ.py
+++ b/Plot_Results_econ.py
@@ -4,7 +4,7 @@ import matplotlib.pyplot as plt
 
 
 # This class takes a results object and provides a library of plot functions to visualize results of interest
-# The plots can be shown on screen (by passing file_name='' to the functions) or saved to a file
+# The plots can be shown on screen (by passing file_path=None to the functions) or saved to a file
 # The first set of functions show results of a run of the model, while the last functions plot the library of
 # pre-defined input functions for different variables
 
@@ -16,7 +16,7 @@ class Plot_Results:
     # stake is the available stake to pledge or delegate
     # creates scatterplots with returns the stakeholder would have obtained pledging/delegating that amount to mix nodes
     # samples mix nodes with amounts of pledge/delegation compatible with the specified stake in the specified year
-    def scatterplot_rewards_staking(self, file_name, stake, quarter):
+    def scatterplot_rewards_staking(self, file_path, stake, quarter):
 
         rewards = self.results.sample_quarterly_rewards_no_compound_vs_saturation(stake)
         sequence_x_vals_pledge = []
@@ -63,16 +63,16 @@ class Plot_Results:
 
         ax.legend()
         ax.grid(True)
-        if len(file_name) < 2:
+        if file_path is None:
             plt.show()
         else:
-            plt.savefig(file_name)
+            plt.savefig(file_path)
         plt.close()
 
     # This function produces a scatterplot where each point has x,y coordinates as indicated in the inputs par_x, par_y
     # selects results for the 12 months of the specified year
     # annualizes results by multiplying monthly results by 12 (no compounding effects accounted for)
-    def plot_scatter_par_y_vs_par_x(self, file_name, par_y, par_x, quarter):
+    def plot_scatter_par_y_vs_par_x(self, file_path, par_y, par_x, quarter):
 
         sequence_containing_x_vals = []
         sequence_containing_y_vals = []
@@ -93,14 +93,14 @@ class Plot_Results:
         ax.set_xlabel(par_x + ' Q' + str(quarter+1), fontsize=14)
         plt.setp(ax.get_yticklabels(), fontsize=14)
         plt.setp(ax.get_xticklabels(), fontsize=14)
-        if len(file_name) < 2:
+        if file_path is None:
             plt.show()
         else:
-            plt.savefig(file_name)
+            plt.savefig(file_path)
         plt.close()
 
     # plots annualized ROS for operators / delegators of nodes of type_node owned by owner
-    def plot_yearly_ROS_distributions(self, file_name, par):
+    def plot_yearly_ROS_distributions(self, file_path, par):
 
         if par == 'ROS_delegator_year':  # clean up the None
             dict_par = self.results.get_dictionary_distribution('ROS_delegator')
@@ -135,17 +135,17 @@ class Plot_Results:
         if par == 'ROS_delegator_year':
             par = 'APY (no compound) delegates'
         ax.set_ylabel('distribution of: ' + str(par), fontsize=14)
-        if len(file_name) < 2:
+        if file_path is None:
             plt.show()
         else:
-            plt.savefig(file_name)
+            plt.savefig(file_path)
         plt.close()
 
     # Distribution of a variable (shown as boxplots) in a set of nodes, one boxplot per interval
-    # if file_name = '' (empty) the function plots on screen, if file_name provided, fig is saved to file_name
+    # if file_path is None the function plots on screen, if file_path provided, fig is saved to file_path directory
     # par is the parameter of interest that we want to display. Possible values are: 'pledge' 'delegated' 'total_stake'
     # 'node_cost' 'received_rewards' 'operator_profit' 'delegate_profit' 'sigma' 'lambda' 'ROS_operator' 'ROS_delegator'
-    def plot_node_parameter_distributions(self, file_name, par):
+    def plot_node_parameter_distributions(self, file_path, par):
 
         dict_par = self.results.get_dictionary_distribution(par)
         if par == 'ROS_delegator' or par == 'delegate_profit' or par == 'APY_delegator':  # clean up the None
@@ -173,14 +173,14 @@ class Plot_Results:
         #elif par in ['pledge', 'total_stake']:
         #    plt.gca().set_ylim(bottom=-20000, top=1300000)
 
-        if len(file_name) < 2:
+        if file_path is None:
             plt.show()
         else:
-            plt.savefig(file_name)
+            plt.savefig(file_path)
         plt.close()
 
     # plots the median return on stake for nodes with >0.9 saturation
-    def plot_median_ROS(self, file_name, median_ROS):
+    def plot_median_ROS(self, file_path, median_ROS):
         annualized_ROS = []
         for val in median_ROS:
             annualized_ROS.append(val*12)
@@ -193,14 +193,14 @@ class Plot_Results:
         plt.setp(ax.get_yticklabels(), fontsize=14)
         ax.legend()
         ax.axhline(y=0, color='r', linewidth=1, linestyle='-')
-        if len(file_name) < 2:
+        if file_path is None:
             plt.show()
         else:
-            plt.savefig(file_name)
+            plt.savefig(file_path)
         plt.close()
 
     # plots the stake of the given stakeholder
-    def plot_stakeholder_staking(self, file_name, stakeholder):
+    def plot_stakeholder_staking(self, file_path, stakeholder):
         fig = plt.figure(figsize=(10, 8), dpi=90, facecolor='w', edgecolor='k')
         ax = fig.add_subplot()
         ax.plot(stakeholder.wealth_compounded_stake, '-', linewidth=2, label='total stake (compounded wealth)')
@@ -213,14 +213,14 @@ class Plot_Results:
         plt.setp(ax.get_yticklabels(), fontsize=14)
         ax.legend()
         ax.axhline(y=0, color='r', linewidth=1, linestyle='-')
-        if len(file_name) < 2:
+        if file_path is None:
             plt.show()
         else:
-            plt.savefig(file_name)
+            plt.savefig(file_path)
         plt.close()
 
     # plots the maximum amount of stake per mix node (saturation point)
-    def plot_stake_saturation_node(self, file_name):
+    def plot_stake_saturation_node(self, file_path):
 
         fig = plt.figure(figsize=(10, 8), dpi=90, facecolor='w', edgecolor='k')
         ax = fig.add_subplot()
@@ -231,14 +231,14 @@ class Plot_Results:
         plt.setp(ax.get_yticklabels(), fontsize=14)
         ax.legend()
         ax.axhline(y=0, color='r', linewidth=1, linestyle='-')
-        if len(file_name) < 2:
+        if file_path is None:
             plt.show()
         else:
-            plt.savefig(file_name)
+            plt.savefig(file_path)
         plt.close()
 
     # plot cumulative liquidity emitted from the mixmining pool
-    def plot_cumulative_mixmining_liquidity(self, file_name):
+    def plot_cumulative_mixmining_liquidity(self, file_path):
 
         cumul = self.results.mixmining_pool[0] - self.results.mixmining_pool[1]
         cumulative_emissions = [cumul]
@@ -261,15 +261,15 @@ class Plot_Results:
         plt.setp(ax.get_yticklabels(), fontsize=14)
         ax.legend()
         #plt.gca().set_ylim(bottom=-10**4, top=15*10**6)
-        if len(file_name) < 2:
+        if file_path is None:
             plt.show()
         else:
-            plt.savefig(file_name)
+            plt.savefig(file_path)
         plt.close()
 
     # plot total income to the network including the split between emitted mixmining rewards and collected bw fees
     # plot rewards rewards distributed and rewards unclaimed (thus returned to mixmining pool)
-    def plot_rewards_distributed_unclaimed(self, file_name):
+    def plot_rewards_distributed_unclaimed(self, file_path):
 
         fig = plt.figure(figsize=(10, 8), dpi=90, facecolor='w', edgecolor='k')
         ax = fig.add_subplot()
@@ -288,14 +288,14 @@ class Plot_Results:
         plt.setp(ax.get_yticklabels(), fontsize=14)
         ax.legend()
         #plt.gca().set_ylim(bottom=-10**4, top=15*10**6)
-        if len(file_name) < 2:
+        if file_path is None:
             plt.show()
         else:
-            plt.savefig(file_name)
+            plt.savefig(file_path)
         plt.close()
 
     # plots the amount of token in the mixmining pool, in circulation, and unvested
-    def plot_vesting_circulating_token(self, file_name):
+    def plot_vesting_circulating_token(self, file_path):
 
         fig = plt.figure(figsize=(10, 8), dpi=90, facecolor='w', edgecolor='k')
         ax = fig.add_subplot()
@@ -308,14 +308,14 @@ class Plot_Results:
         plt.setp(ax.get_yticklabels(), fontsize=14)
         ax.legend()
         #plt.gca().set_ylim(bottom=0)
-        if len(file_name) < 2:
+        if file_path is None:
             plt.show()
         else:
-            plt.savefig(file_name)
+            plt.savefig(file_path)
         plt.close()
 
     # plots the considered bandwidth demand (pre-set input function configured in Config)
-    def plot_total_bw(self, file_name):
+    def plot_total_bw(self, file_path):
 
         fig = plt.figure(figsize=(10, 8), dpi=90, facecolor='w', edgecolor='k')
         ax = fig.add_subplot()
@@ -326,15 +326,15 @@ class Plot_Results:
         plt.setp(ax.get_yticklabels(), fontsize=14)
         ax.legend()
         #plt.gca().set_ylim(bottom=0)
-        if len(file_name) < 2:
+        if file_path is None:
             plt.show()
         else:
-            plt.savefig(file_name)
+            plt.savefig(file_path)
         plt.close()
 
     # plot the number of mix nodes nodes over time
     # the number follows the bandwidth demand in the network (grows from a minimum with demand)
-    def plot_nr_operators(self, file_name):
+    def plot_nr_operators(self, file_path):
 
         fig = plt.figure(figsize=(10, 8), dpi=90, facecolor='w', edgecolor='k')
         ax = fig.add_subplot()
@@ -345,16 +345,16 @@ class Plot_Results:
         plt.setp(ax.get_yticklabels(), fontsize=14)
         ax.legend()
         #plt.gca().set_ylim(bottom=0)
-        if len(file_name) < 2:
+        if file_path is None:
             plt.show()
         else:
-            plt.savefig(file_name)
+            plt.savefig(file_path)
         plt.close()
 
     # produces two figures corresponding to the specified month
     # the first figure shows the distribution of reputation (decreasing order) and its corresponding pledge per node
     # the second figure shows the distribution of pledges (in decreasing size) for the node set
-    def plot_distribution_pledges_stake(self, file_name, month):
+    def plot_distribution_pledges_stake(self, file_path, month):
 
         nr_mixes = len(self.results.network.list_mix[month])
         pledges = []
@@ -392,10 +392,10 @@ class Plot_Results:
         ax.axvline(x=k, color='tab:brown', linewidth=2, linestyle='--')
         ax.legend()
         #plt.gca().set_ylim(bottom=-10000)
-        if len(file_name) < 2:
+        if file_path is None:
             plt.show()
         else:
-            plt.savefig(file_name + 'total_stake.png')
+            plt.savefig(file_path.parent / (file_path.stem + 'total_stake.png'))
         plt.close()
 
         ordered_by_pledge = sorted(ordered_pledges, reverse=True)
@@ -406,15 +406,15 @@ class Plot_Results:
         ax.set_xlabel("Registered nodes (ordered by pledge)", fontsize=12)
         ax.axhline(y=0, color='r', linewidth=1, linestyle='-')
         ax.legend()
-        if len(file_name) < 2:
+        if file_path is None:
             plt.show()
         else:
-            plt.savefig(file_name + 'pledge.png')
+            plt.savefig(file_path.parent / (file_path.stem + 'pledge.png'))
         plt.close()
 
     # Plot pre-defined bandwidth growth functions that are available in Input_Functions
     # useful to see which functions are available and which one to choose for scenarios with more or less bw demand
-    def plot_preset_bw_growth_functions(self, file_name):
+    def plot_preset_bw_growth_functions(self, file_path):
 
         # add types if needed: check Input_Functions_econ.py and see types starting with 'BW_'
         types = ['BW_EXP_CAPPED_10%_HALVES_10x', 'BW_EXP_CAPPED_10%_DROP1/3_4x', 'BW_EXP_GROWTH_6%_STEADY',
@@ -432,10 +432,10 @@ class Plot_Results:
         plt.setp(ax.get_yticklabels(), fontsize=14)
         ax.legend()
         #plt.gca().set_ylim(bottom=0)
-        if len(file_name) < 2:
+        if file_path is None:
             plt.show()
         else:
-            plt.savefig(file_name)
+            plt.savefig(file_path)
         plt.close()
 
     # function takes a vector of function type strings and returns a dictionary with the functions, indexed by

--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ The six classes are:
 
 ## How to run a simulation (basic)
 
-**Step 0**: download the seven .py files to a machine that can run python scripts, making sure you have a subdirectory 'Figures' (`mkdir Figures`) 
+**Step 0**: download the seven .py files to a machine that can run python scripts
 
 **Step 1**: edit the file `Configuration_econ.py` to set the scenario (input variables) that you want to simulate
 
 **Step 2**: run the simulation with the following command: `python3 main.py`
 
-**Step 3**: once the simulation has ended, see the results in the Figures directory
+**Step 3**: once the simulation has ended, see the results in the Output directory
 
 
 ## Tinkering with the simulation

--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 import cProfile
-import os
+#import os
+import pathlib
 import string
 import random
 from Configuration_econ import Config
@@ -7,30 +8,33 @@ from Econ_Results_econ import Econ_Results
 from Plot_Results_econ import Plot_Results
 from Stakeholder_econ import Stakeholder
 
-# returns a random character string of a given length
-# used to generate a randomly named directory to save the results of a simulation run
-def get_random_string(length):
-    # choose from all lowercase, uppercase and numbers
-    letters = string.ascii_lowercase + string.ascii_uppercase + string.digits
-    result_str = ''.join(random.choice(letters) for i in range(length))
-    return result_str
+# returns the sequence number that corresponds to this execution (first simulation run will get '1' and so on)
+# used to generate a directory to save the results of a simulation run
+def get_sequence_number(filename='sequence.dat'):
+
+    try:
+        with open(filename, 'r') as f:
+            seq_nr = int(f.read())
+    except FileNotFoundError:
+        seq_nr = 0
+    seq_nr += 1
+    # replace file contents with current sequence number (to be read during the next simulation run)
+    with open(filename, 'w') as f:
+        f.write(str(seq_nr))
+    return seq_nr
 
 
 # creates a randomly named directory (name with 6 char) inside the Figures folder
 # returns the path of the directory (for saving files in it)
-# triggers an error if a "Figures" folder does not exist in the directory where the main script is running
-def create_dir():
+def create_dirs():
 
-    rnd_dir = get_random_string(6)
-    path = 'Figures/' + rnd_dir + '/'
-    try:
-        os.mkdir(path)
-    except OSError:
-        print("Creation of the directory %s failed" % path)
-        print("Make sure a Figures folder exists")
-    else:
-        print("Successfully created the directory %s " % path)
-    return path
+    seq_nr = get_sequence_number()
+    output_dir = 'Output/' + 'simulation-run-' + str(seq_nr) + '/'
+    output_dir = pathlib.Path.cwd() / output_dir
+    pathlib.Path(output_dir).mkdir(parents=True, exist_ok=True)
+    figures_subdir = output_dir / 'Figures'
+    pathlib.Path(figures_subdir).mkdir()
+    return output_dir, figures_subdir
 
 
 # saves the Configuration_econ.py file in the results directory, so that plots saved in the directory can be
@@ -40,7 +44,7 @@ def save_config_file(path):
     file_config = open('Configuration_econ.py')
     configuration = file_config.read()
     file_config.close()
-    file_to_write = open(path + "config.txt", "w")
+    file_to_write = open(path / "config.txt", "w")
     file_to_write.write(configuration)
     file_to_write.close()
 
@@ -85,9 +89,9 @@ def print_info_list_nodes(sample_month, results):
 # prints the info of the list of nodes existing in sample_month in a txt file
 def save_info_list_nodes(sample_month, path, results):
 
-    file_name = path + "list_nodes_month" + str(sample_month) + ".txt"
+    file_path = path / ("list_nodes_month" + str(sample_month) + ".txt")
 
-    with open(file_name, "w") as f:
+    with open(file_path, "w") as f:
         f.write("-----\n")
         for mix in results.network.list_mix[sample_month]:
             f.write("mix node nr: " + str(mix.serial) + " ; sat level: " + str(mix.sat_level) + "\n")
@@ -109,9 +113,9 @@ def save_info_list_nodes(sample_month, path, results):
 
 def save_info_stakeholders(path, stakeholder):
 
-    file_name = path + "stakeholder_" + str(stakeholder.type_holder) + ".txt"
+    file_path = path / ("stakeholder_" + str(stakeholder.type_holder) + ".txt")
 
-    with open(file_name, "w") as f:
+    with open(file_path, "w") as f:
         f.write("\n===\nType stakeholder: " + stakeholder.type_holder + "\n")
         f.write("liquid: " + str(stakeholder.liquid_stake) + "\n")
         f.write("unvested: " + str(stakeholder.unvested_stake) + "\n")
@@ -126,11 +130,11 @@ def save_info_stakeholders(path, stakeholder):
 # Plot pre-defined bw demand functions available in the Input_Functions library
 def display_preset_functions(plot_res, save_to_file, path):
 
-    file_name = ''
+    file_path = None
     # plot pre-defined bandwidth growth functions
     if save_to_file:
-        file_name = 'plot_preset_bw_growth_functions.png'
-    plot_res.plot_preset_bw_growth_functions(path + file_name)
+        file_path = path / 'plot_preset_bw_growth_functions.png'
+    plot_res.plot_preset_bw_growth_functions(file_path)
 
 
 # This function contains the calls to plot figures with results of interest. If 'save_to_file' is True then files
@@ -138,7 +142,6 @@ def display_preset_functions(plot_res, save_to_file, path):
 # comment out  plot_res.plot_ functions that are not of interest in an evaluation
 def display_save_plots(plot_res, save_to_file, path, config):
 
-    file_name = ''  # if value of path and filename is '' then shows graphs in screen.
     max_years = config.num_intervals // 12
     max_quarters = config.num_intervals // 3
 
@@ -147,13 +150,14 @@ def display_save_plots(plot_res, save_to_file, path, config):
     ####################
 
     # plot node, operator and delegate rewards relative to stake saturation (reputation) of the node
+    file_path = None  # if value of path and filename is None then shows graphs on screen.
     vector_par_y = ['received_rewards', 'operator_profit', 'ROS_delegator', 'activity_percent', 'reserve_percent']
     par_x = 'saturation_percent'
     for quarter in range(max_quarters):  #for year in range(max_years):
         for par_y in vector_par_y:
             if save_to_file:
-                file_name = 'scatter_' + par_y + '_vs_reputation_Q' + str(quarter+1) + '.png'
-            plot_res.plot_scatter_par_y_vs_par_x(path + file_name, par_y, par_x, quarter)
+                file_path = path / ('scatter_' + par_y + '_vs_reputation_Q' + str(quarter+1) + '.png')
+            plot_res.plot_scatter_par_y_vs_par_x(file_path, par_y, par_x, quarter)
 
     # plot node, operator and delegate rewards relative to pledge saturation of the node
     vector_par_y = ['received_rewards', 'operator_profit', 'ROS_delegator']
@@ -161,44 +165,44 @@ def display_save_plots(plot_res, save_to_file, path, config):
     for quarter in range(max_quarters):  #for year in range(max_years):
         for par_y in vector_par_y:
             if save_to_file:
-                file_name = 'scatter_' + par_y + '_vs_' + par_x + '_Q' + str(quarter+1) + '.png'
-            plot_res.plot_scatter_par_y_vs_par_x(path + file_name, par_y, par_x, quarter)
+                file_path = path / ('scatter_' + par_y + '_vs_' + par_x + '_Q' + str(quarter+1) + '.png')
+            plot_res.plot_scatter_par_y_vs_par_x(file_path, par_y, par_x, quarter)
 
     # plot the pledge/reputation distribution among nodes for a few sample months
     for year in range(0, max_years + 1):
         sample_month = max(0, (year-1)*12 + 11)
         if save_to_file:
-            file_name = 'Distribution_month_' + str(sample_month) + '_'
-        plot_res.plot_distribution_pledges_stake(path + file_name, sample_month)
+            file_path = path / ('Distribution_month_' + str(sample_month) + '_')
+        plot_res.plot_distribution_pledges_stake(file_path, sample_month)
 
     # plot rewards from pledging vs delegating a certain amount of stake to a node
     for stake in [10 ** 4, 10 ** 3, 100]:
         for quarter in range(1, max_quarters+1):  #for year in range(1, max_years + 1):
             if save_to_file:
-                file_name = 'scatterplot_returns_staking_' + str(stake) + '_Q' + str(quarter) + '.png'
-            plot_res.scatterplot_rewards_staking(path + file_name, stake, quarter)
+                file_path = path / ('scatterplot_returns_staking_' + str(stake) + '_Q' + str(quarter) + '.png')
+            plot_res.scatterplot_rewards_staking(file_path, stake, quarter)
 
     # Return on Stake for delegates: yearly delegate rewards divided by the amount of delegated stake (per node)
     for par in ['ROS_delegator_year']:
         if save_to_file:
-            file_name = 'APY_delegates_annualized.png'
-        plot_res.plot_yearly_ROS_distributions(path + file_name, par)
+            file_path = path / 'APY_delegates_annualized.png'
+        plot_res.plot_yearly_ROS_distributions(file_path, par)
 
     ####################
     # FIGS TYPE 2: Plot distributions of values (boxplots) over nodes such as: node pledges, received rewards, profits
     # for operators / delegates, etc.
-    # In the function plot_node_parameter_distributions(file_name, par) the inputs are:
-    # file_name: pass empty value '' to show graphs on screen -- otherwise a .png file name to save the figure to file
+    # In the function plot_node_parameter_distributions(file_path, par) the inputs are:
+    # file_path: pass None to show graphs on screen -- otherwise a .png file name to save the figure to file
     # par: parameter of interest to be shown, can take the values: 'pledge' 'delegated' 'total_stake' 'node_cost'
     # 'received_rewards' 'operator_profit' 'delegate_profit' 'sigma' 'lambda' 'ROS_operator' (monthly)
     # 'ROS_delegator' (monthly), 'activity_percent', 'reserve_percent', and more. Some illustrative examples below.
     ####################
 
-    file_name = ''  # if value of path and filename is '' then shows graphs in screen.
+    file_path = None  # if value of path and filename is None then shows graphs on screen.
     for par in ['pledge', 'total_stake', 'received_rewards', 'operator_profit', 'APY_delegator', 'activity_percent']:
         if save_to_file:
-            file_name = 'nodes_distribution_' + str(par) + '.png'
-        plot_res.plot_node_parameter_distributions(path + file_name, par)
+            file_path = path / ('nodes_distribution_' + str(par) + '.png')
+        plot_res.plot_node_parameter_distributions(file_path, par)
 
     ####################
     # FIGS TYPE 3: Plot distributions of global system variables and averages (instead of per-node values/distributions)
@@ -207,44 +211,44 @@ def display_save_plots(plot_res, save_to_file, path, config):
 
     # plot the amount of token in the mixmining pool, in circulation, and unvested
     if save_to_file:
-        file_name = 'plot_vesting_circulating_token.png'
-    plot_res.plot_vesting_circulating_token(path + file_name)
+        file_path = path / 'plot_vesting_circulating_token.png'
+    plot_res.plot_vesting_circulating_token(file_path)
 
     # plot the cumulative net liquidity coming from the mixmining pool (accounting for unclaimed rewards)
     if save_to_file:
-        file_name = 'plot_cumulative_mixmining_liquidity.png'
-    plot_res.plot_cumulative_mixmining_liquidity(path + file_name)
+        file_path = path / 'plot_cumulative_mixmining_liquidity.png'
+    plot_res.plot_cumulative_mixmining_liquidity(file_path)
 
     # plot the value of the stake saturation point (global value for all nodes, updated per interval)
     if save_to_file:
-        file_name = 'plot_stake_saturation_node.png'
-    plot_res.plot_stake_saturation_node(path + file_name)
+        file_path = path / 'plot_stake_saturation_node.png'
+    plot_res.plot_stake_saturation_node(file_path)
 
     # plot the aggregate amount of rewards distributed and returned to the pool (unclaimed)
     if save_to_file:
-        file_name = 'plot_rewards_distributed_unclaimed.png'
-    plot_res.plot_rewards_distributed_unclaimed(path + file_name)
+        file_path = path / 'plot_rewards_distributed_unclaimed.png'
+    plot_res.plot_rewards_distributed_unclaimed(file_path)
 
     # plot the bandwidth demand (note that this is a pre-set function chosen according to Configuration variables)
     if save_to_file:
-        file_name = 'plot_total_bw.png'
+        file_path = path / 'plot_total_bw.png'
     if config.type_bw_growth != 'BW_ZERO':  # if 'BW_ZERO' it's simply constant at zero, nothing to plot
-        plot_res.plot_total_bw(path + file_name)
+        plot_res.plot_total_bw(file_path)
 
     # plot the number of operators of each type over time (if 'BW_ZERO' it's simply constant value in config)
     if save_to_file:
-        file_name = 'plot_nr_operators.png'
+        file_path = path / 'plot_nr_operators.png'
     if config.type_bw_growth != 'BW_ZERO':
-        plot_res.plot_nr_operators(path + file_name)
+        plot_res.plot_nr_operators(file_path)
 
 
 def stakeholder_plots(plot_res, save_to_file, path, config):
 
-    file_name = ""
+    file_path = None
     median_ROS = plot_res.results.get_median_ROS_reputable_node()
     if save_to_file:
-        file_name = 'median_ROS_high_rep_nodes.png'
-    plot_res.plot_median_ROS(path + file_name, median_ROS)
+        file_path = path / 'median_ROS_high_rep_nodes.png'
+    plot_res.plot_median_ROS(file_path, median_ROS)
     print("median ROS:" + str(median_ROS))
 
     stakeholders = ['TESTNET', 'OPTION_1', 'OPTION_2', 'VALIDATOR_100k', 'VALIDATOR_200k', 'VALIDATOR_400k',
@@ -253,8 +257,8 @@ def stakeholder_plots(plot_res, save_to_file, path, config):
         stakeholder = Stakeholder(s, config)
         stakeholder.compute_rewards(median_ROS)
         if save_to_file:
-            file_name = 'stakeholder_' + s + '.png'
-        plot_res.plot_stakeholder_staking(path + file_name, stakeholder)
+            file_path = path / ('stakeholder_' + s + '.png')
+        plot_res.plot_stakeholder_staking(file_path, stakeholder)
         save_info_stakeholders(path, stakeholder)
 
 # main function that instantiates the classes to run a simulation of the system with a the given configuration
@@ -262,10 +266,10 @@ def run_model(save_to_file):
 
     # depending on save_to_file, create a randomly named directory for saving figures, or set path to empty
     if save_to_file:
-        path = create_dir()  # create a randomly name directory to store the figures
-        save_config_file(path)  # saves the configuration parameters in a file config.txt
+        output_dir, figures_subdir = create_dirs()  # create a randomly name directory to store the figures
+        save_config_file(output_dir)  # saves the configuration parameters in a file config.txt
     else:
-        path = ''  # empty path and file_name will show figs on screen instead of saving them to file
+        output_dir, figures_subdir = None, None  # show data / figs on screen instead of saving them to files
 
     # FIRST create configuration object with all the input variables
     config = Config()
@@ -278,12 +282,12 @@ def run_model(save_to_file):
     plot_res = Plot_Results(results)
 
     # FOURTH call the desired plotting functions to look into system variables and results of interest
-    display_save_plots(plot_res, save_to_file, path, config)
+    display_save_plots(plot_res, save_to_file, figures_subdir, config)
 
     # FIFTH print the list of nodes for a month to see if all node variables look ok
     for sample_month in [0]:#[0, 11]:
         if save_to_file:  # save info in a file
-            save_info_list_nodes(sample_month, path, results)
+            save_info_list_nodes(sample_month, output_dir, results)
         else:  # print the info to screen
             print_info_list_nodes(sample_month, results)
 


### PR DESCRIPTION
Some general restructuring of the output directories
 - Removed the requirement to have a pre-existing directory to store the output of the simulation (I also renamed the relevant directory from Figures to Output).  
 - Used a .dat file to store the number of simulations that have been run on a local machine, so that the subdirectories for the results of individual simulation runs are named based on the run's sequence number, rather than a random string. 
 - Created subdirectory for Figures inside each simulation run directory (to separate images from text files).

I hope contributions are welcome :) 